### PR TITLE
GROW-340 Implement custom alert

### DIFF
--- a/Planz.xcodeproj/project.pbxproj
+++ b/Planz.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		6F4759B528D9D0CF005CC91B /* PlanzUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4759B428D9D0CF005CC91B /* PlanzUITests.swift */; };
 		6F4759B728D9D0CF005CC91B /* PlanzUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4759B628D9D0CF005CC91B /* PlanzUITestsLaunchTests.swift */; };
 		6F4759C628D9D146005CC91B /* AppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4759C528D9D146005CC91B /* AppView.swift */; };
+		6F75F08A28FD241C00497FAD /* PLAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F75F08928FD241C00497FAD /* PLAlert.swift */; };
 		6F81F3D028EE78550005BAAA /* AppPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 6F81F3CF28EE78550005BAAA /* AppPackage */; };
 /* End PBXBuildFile section */
 
@@ -45,6 +46,7 @@
 		6F4759B428D9D0CF005CC91B /* PlanzUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanzUITests.swift; sourceTree = "<group>"; };
 		6F4759B628D9D0CF005CC91B /* PlanzUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanzUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		6F4759C528D9D146005CC91B /* AppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppView.swift; sourceTree = "<group>"; };
+		6F75F08928FD241C00497FAD /* PLAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PLAlert.swift; sourceTree = "<group>"; };
 		6F81F3CD28EE77C60005BAAA /* AppPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AppPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -101,6 +103,7 @@
 			children = (
 				6F47599928D9D0CE005CC91B /* PlanzApp.swift */,
 				6F4759C528D9D146005CC91B /* AppView.swift */,
+				6F75F08B28FD434F00497FAD /* PLAlert */,
 				6F47599D28D9D0CF005CC91B /* Assets.xcassets */,
 				6F47599F28D9D0CF005CC91B /* Preview Content */,
 			);
@@ -130,6 +133,14 @@
 				6F4759B628D9D0CF005CC91B /* PlanzUITestsLaunchTests.swift */,
 			);
 			path = PlanzUITests;
+			sourceTree = "<group>";
+		};
+		6F75F08B28FD434F00497FAD /* PLAlert */ = {
+			isa = PBXGroup;
+			children = (
+				6F75F08928FD241C00497FAD /* PLAlert.swift */,
+			);
+			path = PLAlert;
 			sourceTree = "<group>";
 		};
 		6F81F3CE28EE78550005BAAA /* Frameworks */ = {
@@ -273,6 +284,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6F75F08A28FD241C00497FAD /* PLAlert.swift in Sources */,
 				6F4759C628D9D146005CC91B /* AppView.swift in Sources */,
 				6F47599A28D9D0CE005CC91B /* PlanzApp.swift in Sources */,
 			);

--- a/Planz/PLAlert/PLAlert.swift
+++ b/Planz/PLAlert/PLAlert.swift
@@ -108,16 +108,18 @@ extension View {
     @ViewBuilder func alert(
       _ store: Store<PLAlertState?, PLAlertAction>
     ) -> some View {
-        IfLetStore(
-            store,
-            then: { store in
-                ZStack {
+        ZStack {
+            self
+            
+            IfLetStore(
+                store,
+                then: { store in
                     Color.black.opacity(0.75).ignoresSafeArea()
                     
                     PLAlert(store: store)
                 }
-            }
-        )
+            )
+        }
     }
 }
 
@@ -136,12 +138,13 @@ fileprivate struct R {
     }
 }
 
-//struct TestState: Equatable {
-//    var alert: PLAlertState?
-//}
-//
+struct TestState: Equatable {
+    var alert: PLAlertState?
+}
+
 //enum TestAction {
 //    case onAppear
+//    case showAlertTapped
 //    case alert(PLAlertAction)
 //}
 //
@@ -155,13 +158,14 @@ fileprivate struct R {
 //    }
 //
 //    var body: some View {
-//        Rectangle()
+//        Button(action: {
+//            viewStore.send(.showAlertTapped)
+//        }, label: {
+//            Text("Show Alert")
+//        })
 //            .alert(
 //                store.scope(state: \.alert, action: TestAction.alert)
 //            )
-//            .onAppear {
-//                viewStore.send(.onAppear)
-//            }
 //    }
 //}
 //
@@ -172,6 +176,16 @@ fileprivate struct R {
 //> { state, action, _ in
 //    switch action {
 //    case .onAppear:
+//        state.alert = .init(
+//            title: "알림",
+//            description: "작업한 내용이 저장되지 않고 홈화면으로 이동합니다. 진행하시겠습니까?",
+//            buttons: [
+//                .cancel(action: .cancel, title: "취소"),
+//                .default(action: .confirm, title: "확인")
+//            ]
+//        )
+//        return .none
+//    case .showAlertTapped:
 //        state.alert = .init(
 //            title: "알림",
 //            description: "작업한 내용이 저장되지 않고 홈화면으로 이동합니다. 진행하시겠습니까?",

--- a/Planz/PLAlert/PLAlert.swift
+++ b/Planz/PLAlert/PLAlert.swift
@@ -1,0 +1,191 @@
+//
+//  PLAlert.swift
+//  Planz
+//
+//  Created by junyng on 2022/10/17.
+//  Copyright © 2022 Team-Planz. All rights reserved.
+//
+
+import ComposableArchitecture
+import SwiftUI
+
+struct PLAlertState: Equatable {
+    let title: String
+    var description: String
+    var buttons: [Button]
+    
+    struct Button: Equatable {
+        let action: PLAlertAction
+        let title: String
+        let style: Style
+        
+        enum Style {
+            case `default`
+            case cancel
+        }
+        
+        static func `default`(
+            action: PLAlertAction,
+            title: String
+        ) -> Self {
+            Self(action: action, title: title, style: .default)
+        }
+        
+        static func cancel(
+            action: PLAlertAction,
+            title: String
+        ) -> Self {
+            Self(action: action, title: title, style: .cancel)
+        }
+    }
+}
+
+struct PLAlert: View {
+    let store: Store<PLAlertState, PLAlertAction>
+    @ObservedObject var viewStore: ViewStore<PLAlertState, PLAlertAction>
+    
+    init(store: Store<PLAlertState, PLAlertAction>) {
+        self.store = store
+        self.viewStore = ViewStore(store)
+    }
+    
+    var body: some View {
+        LazyVStack(spacing: 0) {
+            LazyVStack(spacing: 12) {
+                Text(viewStore.title)
+                    .font(.system(size: 16))
+                    .bold()
+                    .foregroundColor(R.color.gray900)
+                
+                Text(viewStore.description)
+                    .font(.system(size: 13))
+                    .foregroundColor(R.color.gray900)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+            }
+            .padding(.top, 24)
+            .padding(.horizontal, 30)
+            
+            HStack(spacing: 12) {
+                ForEach(0..<viewStore.buttons.count, id: \.self) {
+                    let button = viewStore.buttons[$0]
+                    Button(action: {
+                        viewStore.send(button.action)
+                    }) {
+                        Text(button.title)
+                            .font(.system(size: 16))
+                            .foregroundColor(button.style == .default
+                                             ? R.color.gray100 : R.color.gray700)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: C.buttonHeight)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(button.style == .default
+                                          ? R.color.purple900 : R.color.gray200)
+                            )
+                    }
+                }
+            }
+            .padding(20)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.white)
+        )
+        .frame(
+            width: C.alertSize.width,
+            height: C.alertSize.height
+        )
+    }
+}
+
+enum PLAlertAction {
+    case confirm
+    case cancel
+}
+
+extension View {
+    @ViewBuilder func alert(
+      _ store: Store<PLAlertState?, PLAlertAction>
+    ) -> some View {
+        IfLetStore(
+            store,
+            then: { store in
+                ZStack {
+                    Color.black.opacity(0.75).ignoresSafeArea()
+                    
+                    PLAlert(store: store)
+                }
+            }
+        )
+    }
+}
+
+fileprivate struct C {
+    static let buttonHeight: CGFloat = 51
+    static let alertSize: CGSize = .init(width: 280, height: 191)
+}
+
+fileprivate struct R {
+    struct color {
+        static let gray100: Color = .init(red: 243/255, green: 245/255, blue: 248/255)
+        static let gray200: Color = .init(red: 205/255, green: 210/255, blue: 217/255)
+        static let gray700: Color = .init(red: 106/255, green: 112/255, blue: 122/255)
+        static let gray900: Color = .init(red: 2/255, green: 2/255, blue: 2/255)
+        static let purple900: Color = .init(red: 102/255, green: 113/255, blue: 246/255)
+    }
+}
+
+//struct TestState: Equatable {
+//    var alert: PLAlertState?
+//}
+//
+//enum TestAction {
+//    case onAppear
+//    case alert(PLAlertAction)
+//}
+//
+//struct TestView: View {
+//    let store: Store<TestState, TestAction>
+//    @ObservedObject var viewStore: ViewStore<TestState, TestAction>
+//
+//    init(store: Store<TestState, TestAction>) {
+//        self.store = store
+//        self.viewStore = ViewStore(store)
+//    }
+//
+//    var body: some View {
+//        Rectangle()
+//            .alert(
+//                store.scope(state: \.alert, action: TestAction.alert)
+//            )
+//            .onAppear {
+//                viewStore.send(.onAppear)
+//            }
+//    }
+//}
+//
+//let testReducer = Reducer<
+//    TestState,
+//    TestAction,
+//    Void
+//> { state, action, _ in
+//    switch action {
+//    case .onAppear:
+//        state.alert = .init(
+//            title: "알림",
+//            description: "작업한 내용이 저장되지 않고 홈화면으로 이동합니다. 진행하시겠습니까?",
+//            buttons: [
+//                .cancel(action: .cancel, title: "취소"),
+//                .default(action: .confirm, title: "확인")
+//            ]
+//        )
+//        return .none
+//    case .alert(.cancel):
+//        print("canceled")
+//        state.alert = nil
+//        return .none
+//    default:
+//        return .none
+//    }
+//}


### PR DESCRIPTION
<img width="300" alt="스크린샷 2022-10-17 오후 9 22 07" src="https://user-images.githubusercontent.com/8664413/196176425-2bfd170c-9312-4122-a562-f17ff77e0c45.png">

커스텀 얼럿을 작성하였습니다

얼럿은 title + [Button] 조합의 상태를 가지며
탭 액션시, Button.Action을 실행하게 됩니다.

사용법은 주석 처리해두었습니다. 얼럿 사용에 대한 설명을 드리면..
1. 얼럿을 띄울 뷰(`TestView`)의 body에 .alert(_ store: Store<PLAlertState?, PLAlertAction>) modifier 등록
2. 얼럿을 띄울 부모 뷰(TestReducer)에서 `PLAlertState`를 생성시 얼럿이 보여짐
3. Button.Action을 탭 하면 `TestReducer`에서 액션을 처리하여(PLAlertAction.confirm, .cancel) 얼럿을 가림

해당 소스가 모듈에 포함되어야할지 앱 타겟에 포함되어야할지 
사소한 고민이 있는데 팀원분들 의견이 필요합니다 .... ㅎㅎ