### PR TITLE
Add swiftformat 

### DIFF
--- a/AppPackage/Package.swift
+++ b/AppPackage/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
     products: [
         .library(
             name: "AppPackage",
-            targets: ["AppPackage", "TimeTableFeature"])
+            targets: ["AppPackage", "TimeTableFeature"]
+        )
     ],
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture.git", from: "0.47.2"),
@@ -23,11 +24,13 @@ let package = Package(
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "Introspect", package: "SwiftUI-Introspect"),
                 .product(name: "Then", package: "Then")
-            ]),
+            ]
+        ),
         .target(
             name: "TimeTableFeature",
             dependencies: [
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
-            ])
+            ]
+        )
     ]
 )

--- a/AppPackage/Sources/TimeTableFeature/Day+Extensions.swift
+++ b/AppPackage/Sources/TimeTableFeature/Day+Extensions.swift
@@ -32,8 +32,8 @@ extension DateFormatter {
 
 extension Array where Element == TimeTableState.Day {
     static var weekend: Self {
-        return (0..<7).map { index -> Element in
-            return .init(date: .init(timeIntervalSinceNow: .day * TimeInterval(index)))
+        return (0 ..< 7).map { index -> Element in
+            .init(date: .init(timeIntervalSinceNow: .day * TimeInterval(index)))
         }
     }
 }

--- a/AppPackage/Sources/TimeTableFeature/TimeTableView.swift
+++ b/AppPackage/Sources/TimeTableFeature/TimeTableView.swift
@@ -15,7 +15,7 @@ public struct TimeTableState: Equatable {
         let date: Date
 
         init(date: Date) {
-            self.id = date.hashValue
+            id = date.hashValue
             self.date = date
         }
     }
@@ -60,7 +60,7 @@ public struct TimeTableState: Equatable {
         self.endTime = endTime
         self.timeInterval = timeInterval
         self.timeMarkerInterval = timeMarkerInterval
-        self.timeRanges = stride(
+        timeRanges = stride(
             from: startTime,
             to: endTime,
             by: timeInterval
@@ -72,7 +72,7 @@ public struct TimeTableState: Equatable {
                 isStartTimeVisible: $0.truncatingRemainder(dividingBy: timeMarkerInterval) == 0
             )
         }
-        self.timeCells = .init(
+        timeCells = .init(
             repeating: .init(repeating: .deselected, count: timeRanges.count),
             count: days.count
         )
@@ -90,8 +90,8 @@ public let timeTableReducer = Reducer<
 > { state, action, _ in
     switch action {
     case let .timeCellTapped(row, column):
-        guard 0 <= row && row < state.timeRanges.count else { return .none }
-        guard 0 <= column && column < state.days.count else { return .none }
+        guard row >= 0, row < state.timeRanges.count else { return .none }
+        guard column >= 0, column < state.days.count else { return .none }
         state.timeCells[column][row].toggle()
         return .none
     }
@@ -103,14 +103,14 @@ public struct TimeTableView: View {
 
     public init(store: Store<TimeTableState, TimeTableAction>) {
         self.store = store
-        self.viewStore = ViewStore(store)
+        viewStore = ViewStore(store)
     }
 
     public var body: some View {
         GeometryReader { proxy in
             let dayCellWidth: CGFloat = viewStore.days.count <= LayoutConstant.visibleDaysCount
-            ? proxy.size.width / CGFloat(viewStore.days.count)
-            : max((proxy.size.width - LayoutConstant.trailingSpace), 0) / CGFloat(LayoutConstant.visibleDaysCount)
+                ? proxy.size.width / CGFloat(viewStore.days.count)
+                : max(proxy.size.width - LayoutConstant.trailingSpace, 0) / CGFloat(LayoutConstant.visibleDaysCount)
 
             ScrollView(.vertical, showsIndicators: false) {
                 ScrollView(.horizontal, showsIndicators: false) {
@@ -181,7 +181,7 @@ public struct TimeTableView: View {
 
     var timeline: some View {
         LazyVStack(spacing: 0) {
-            ForEach(0..<viewStore.timeRanges.count, id: \.self) {
+            ForEach(0 ..< viewStore.timeRanges.count, id: \.self) {
                 let timeRange = viewStore.timeRanges[$0]
                 Group {
                     if timeRange.isStartTimeVisible {
@@ -224,12 +224,12 @@ public struct TimeTableView: View {
                 Section(
                     header: timeline
                 ) {
-                    ForEach(0..<columns, id: \.self) { column in
-                        ForEach(0..<rows, id: \.self) { row in
+                    ForEach(0 ..< columns, id: \.self) { column in
+                        ForEach(0 ..< rows, id: \.self) { row in
                             Rectangle()
                                 .frame(width: (proxy.size.width - LayoutConstant.timelineWidth) / CGFloat(columns))
                                 .foregroundColor(viewStore.timeCells[column][row] == .selected
-                                                 ? Resource.PlanzColor.purple900 : Resource.PlanzColor.white200)
+                                    ? Resource.PlanzColor.purple900 : Resource.PlanzColor.white200)
                                 .clipShape(Rectangle())
                                 .overlay(
                                     VerticalLine()
@@ -268,7 +268,7 @@ public struct TimeTableView: View {
     }
 }
 
-private struct LayoutConstant {
+private enum LayoutConstant {
     static let headerHeight: CGFloat = 84
     static let lineWidth: CGFloat = 1
     static let timelineWidth: CGFloat = 62
@@ -279,18 +279,18 @@ private struct LayoutConstant {
     static let timeCellHeight: CGFloat = 40
 }
 
-private struct Resource {
-    struct PlanzColor {
-        static let gray200: Color = .init(red: 205/255, green: 210/255, blue: 217/255)
-        static let gray500: Color = .init(red: 156/255, green: 163/255, blue: 173/255)
-        static let gray800: Color = .init(red: 2/255, green: 2/255, blue: 2/255)
-        static let gray900: Color = .init(red: 91/255, green: 104/255, blue: 122/255)
-        static let white200: Color = .init(red: 251/255, green: 251/255, blue: 251/255)
-        static let purple100: Color = .init(red: 251/255, green: 251/255, blue: 251/255)
-        static let purple900: Color = .init(red: 102/255, green: 113/255, blue: 246/255)
-        static let dayCellBackground: Color = .init(red: 232/255, green: 234/255, blue: 254/255)
-        static let dayCellBorder: Color = .init(red: 206/255, green: 210/255, blue: 252/255)
-        static let timeCellBorder: Color = .init(red: 232/255, green: 234/255, blue: 237/255)
+private enum Resource {
+    enum PlanzColor {
+        static let gray200: Color = .init(red: 205 / 255, green: 210 / 255, blue: 217 / 255)
+        static let gray500: Color = .init(red: 156 / 255, green: 163 / 255, blue: 173 / 255)
+        static let gray800: Color = .init(red: 2 / 255, green: 2 / 255, blue: 2 / 255)
+        static let gray900: Color = .init(red: 91 / 255, green: 104 / 255, blue: 122 / 255)
+        static let white200: Color = .init(red: 251 / 255, green: 251 / 255, blue: 251 / 255)
+        static let purple100: Color = .init(red: 251 / 255, green: 251 / 255, blue: 251 / 255)
+        static let purple900: Color = .init(red: 102 / 255, green: 113 / 255, blue: 246 / 255)
+        static let dayCellBackground: Color = .init(red: 232 / 255, green: 234 / 255, blue: 254 / 255)
+        static let dayCellBorder: Color = .init(red: 206 / 255, green: 210 / 255, blue: 252 / 255)
+        static let timeCellBorder: Color = .init(red: 232 / 255, green: 234 / 255, blue: 237 / 255)
     }
 }
 

--- a/Planz.xcodeproj/project.pbxproj
+++ b/Planz.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		49D91E12297999AC00A5C2BA /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 49D91E11297999AC00A5C2BA /* .swiftlint.yml */; };
 		49D91E1529799F9D00A5C2BA /* runLint.sh in Resources */ = {isa = PBXBuildFile; fileRef = 49D91E1429799F9D00A5C2BA /* runLint.sh */; };
+		49F41A7D2984C519008A3AFA /* runSwiftformat.sh in Resources */ = {isa = PBXBuildFile; fileRef = 49F41A7C2984C519008A3AFA /* runSwiftformat.sh */; };
 		6F47599A28D9D0CE005CC91B /* PlanzApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F47599928D9D0CE005CC91B /* PlanzApp.swift */; };
 		6F47599E28D9D0CF005CC91B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F47599D28D9D0CF005CC91B /* Assets.xcassets */; };
 		6F4759A128D9D0CF005CC91B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6F4759A028D9D0CF005CC91B /* Preview Assets.xcassets */; };
@@ -39,6 +40,7 @@
 /* Begin PBXFileReference section */
 		49D91E11297999AC00A5C2BA /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		49D91E1429799F9D00A5C2BA /* runLint.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = runLint.sh; sourceTree = "<group>"; };
+		49F41A7C2984C519008A3AFA /* runSwiftformat.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = runSwiftformat.sh; sourceTree = "<group>"; };
 		6F47599628D9D0CE005CC91B /* Planz.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Planz.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F47599928D9D0CE005CC91B /* PlanzApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanzApp.swift; sourceTree = "<group>"; };
 		6F47599D28D9D0CF005CC91B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 		6F47598D28D9D0CE005CC91B = {
 			isa = PBXGroup;
 			children = (
+				49F41A7C2984C519008A3AFA /* runSwiftformat.sh */,
 				49D91E1429799F9D00A5C2BA /* runLint.sh */,
 				49D91E11297999AC00A5C2BA /* .swiftlint.yml */,
 				6F81F3CD28EE77C60005BAAA /* AppPackage */,
@@ -152,7 +155,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6F4759BA28D9D0CF005CC91B /* Build configuration list for PBXNativeTarget "Planz" */;
 			buildPhases = (
-				49D91E102979991000A5C2BA /* Swift Lint */,
+				49F41A7B2984C491008A3AFA /* Run Swiftformat */,
+				49D91E102979991000A5C2BA /* Run Swift Lint */,
 				6F47599228D9D0CE005CC91B /* Sources */,
 				6F47599328D9D0CE005CC91B /* Frameworks */,
 				6F47599428D9D0CE005CC91B /* Resources */,
@@ -255,6 +259,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				49D91E12297999AC00A5C2BA /* .swiftlint.yml in Resources */,
+				49F41A7D2984C519008A3AFA /* runSwiftformat.sh in Resources */,
 				6F4759A128D9D0CF005CC91B /* Preview Assets.xcassets in Resources */,
 				6F47599E28D9D0CF005CC91B /* Assets.xcassets in Resources */,
 				49D91E1529799F9D00A5C2BA /* runLint.sh in Resources */,
@@ -278,7 +283,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		49D91E102979991000A5C2BA /* Swift Lint */ = {
+		49D91E102979991000A5C2BA /* Run Swift Lint */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -287,7 +292,7 @@
 			);
 			inputPaths = (
 			);
-			name = "Swift Lint";
+			name = "Run Swift Lint";
 			outputFileListPaths = (
 			);
 			outputPaths = (
@@ -295,6 +300,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "sh runLint.sh\n";
+		};
+		49F41A7B2984C491008A3AFA /* Run Swiftformat */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Swiftformat";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nsh runSwiftformat.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/PlanzTests/PlanzTests.swift
+++ b/PlanzTests/PlanzTests.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2022 Team-Planz. All rights reserved.
 //
 
-import XCTest
 @testable import Planz
+import XCTest
 
 final class PlanzTests: XCTestCase {
-
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
@@ -29,9 +28,8 @@ final class PlanzTests: XCTestCase {
 
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
-        self.measure {
+        measure {
             // Put the code you want to measure the time of here.
         }
     }
-
 }

--- a/PlanzUITests/PlanzUITests.swift
+++ b/PlanzUITests/PlanzUITests.swift
@@ -9,7 +9,6 @@
 import XCTest
 
 final class PlanzUITests: XCTestCase {
-
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
 

--- a/PlanzUITests/PlanzUITestsLaunchTests.swift
+++ b/PlanzUITests/PlanzUITestsLaunchTests.swift
@@ -9,7 +9,6 @@
 import XCTest
 
 final class PlanzUITestsLaunchTests: XCTestCase {
-
     override class var runsForEachTargetApplicationUIConfiguration: Bool {
         true
     }

--- a/runSwiftformat.sh
+++ b/runSwiftformat.sh
@@ -1,0 +1,7 @@
+
+export PATH="$PATH:/opt/homebrew/bin"
+if which swiftformat >/dev/null; then
+  swiftformat . --disable trailingCommas
+else
+  echo "warning: SwiftFormat not installed, download from https://github.com/nicklockwood/SwiftFormat"
+fi


### PR DESCRIPTION
## 작업 내용
- [Swiftformat](https://github.com/nicklockwood/SwiftFormat)을 추가합니다. **링크속 페이지를 참고해 homebrew로 swiftlint를 설치해주시면 감사하겠습니다** 
- Build phase에서 Swift format을 돌아가게 합니다. Swift lint 체크전 Swift format을 먼저 동작하게 해서, 띄어쓰기 같은 lint 에러는 포맷터가 자동으로 수정해줍니다. 
- Formatter가 동작하더라도 변수명 Lint error 같이 포맷터가 수정할 수 없는 영역은 본인이 직접 수정을 해주셔야 합니다
- Swiftformat을 동작해서 기존 프로젝트에서 발생할 수 있던 lint error를 수정합니다.
- swiftformat 동작 옵션에 disable trailing comma를 한 이유는, 해당 옵션을 끄지 않으면 모든 배열의 마지막 요소에도 컴마를 붙이는데 이는 현재 우리의 lint rule에 위배되는 rule이기 때문입니다.

<br>

## 실행 화면

| Formatter로 인해 과도한 띄어쓰기가 자동으로 적용된 모습 | 
| ----------- | 
|  ![Jan-28-2023 12-16-02](https://user-images.githubusercontent.com/19788090/215239493-d93064e9-0b67-470a-b632-a1792af06449.gif) | 


<br>

## Check List
- [ ] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [x] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [ ] 관련 이슈 연결
