### PR TITLE
[PI-22] Fix image options

### DIFF
--- a/AppPackage/Sources/DesignSystem/Resources/Icon.xcassets/homeTab.imageset/Contents.json
+++ b/AppPackage/Sources/DesignSystem/Resources/Icon.xcassets/homeTab.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/AppPackage/Sources/DesignSystem/Resources/Icon.xcassets/promiseManagementTab.imageset/Contents.json
+++ b/AppPackage/Sources/DesignSystem/Resources/Icon.xcassets/promiseManagementTab.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
## ISSUE
- resolved #[[PI-22]](https://planz-growth.atlassian.net/browse/PI-22)

<br>

## 작업 내용
- tab view icon의 색상이 의도한 대로 노출되어야 합니다.


<br>

## 실행 화면

| Screen Shot | Screen Shot |
| ----------- | ----------- |
|<img width="391" alt="Screenshot 2023-03-29 at 17 26 30" src="https://user-images.githubusercontent.com/48466830/228473782-2280f9ae-d40f-4b76-b7c8-bacb41d368c8.png">
|


<br>

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [ ] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
