### PR TITLE
[PI-24] Fix to add signup request

### DIFF
--- a/AppPackage/Sources/LoginFeature/LoginView.swift
+++ b/AppPackage/Sources/LoginFeature/LoginView.swift
@@ -25,16 +25,20 @@ public struct Login: ReducerProtocol {
 
     public init() {}
 
+    @Dependency(\.apiClient) var apiClient: APIClient
+
     public var body: some ReducerProtocol<State, Action> {
         Reduce { _, action in
             switch action {
             case .kakaoButtonTapped:
                 return .task {
-                    await .authorizeResponse(
-                        TaskResult {
-                            try await APIClient.liveValue.authenticate()
-                        }
-                    )
+                    let result = await TaskResult {
+                        try await apiClient.authenticate()
+                    }
+                    if case .success = result {
+                        try? await apiClient.request(route: .user(.signup))
+                    }
+                    return .authorizeResponse(result)
                 }
             case .browsingTapped:
                 return .none


### PR DESCRIPTION
## ISSUE
- resolved [Pl-24](https://planz-growth.atlassian.net/browse/PI-24)

<br>

## 작업 내용
- 로그인 뷰에서 회원가입 요청을 추가하였습니다

현재로썬 앱단에서 유저의 회원가입 여부를 확인할 수 없기 때문에
(로그인 API 없음)
로그인 요청 이후 회원가입을 요청하도록 수정하였습니다

<br>

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [ ] CI/CD 통과 여부
- [x] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
