### PR TITLE
[PI-17] Fix promise detail view without store

### DIFF
--- a/AppPackage/.swiftpm/xcode/xcshareddata/xcschemes/AppPackage.xcscheme
+++ b/AppPackage/.swiftpm/xcode/xcshareddata/xcschemes/AppPackage.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AppPackage"
+               BuildableName = "AppPackage"
+               BlueprintName = "AppPackage"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AppPackage"
+            BuildableName = "AppPackage"
+            BlueprintName = "AppPackage"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AppPackage/Sources/CommonView/PromiseDetailView.swift
+++ b/AppPackage/Sources/CommonView/PromiseDetailView.swift
@@ -5,112 +5,74 @@
 //  Created by Sujin Jin on 2023/03/06.
 //
 
-import ComposableArchitecture
 import DesignSystem
 import SwiftUI
 import SwiftUIHelper
-
-public struct PromiseDetailFeature: ReducerProtocol {
-    public init() {}
-
-    public struct State: Equatable, Identifiable {
-        public let id: UUID
-        let title: String
-        let theme: String
-        let date: String
-        let place: String
-        let participants: [String]
-
-        public init(
-            id: UUID,
-            title: String,
-            theme: String,
-            date: String,
-            place: String,
-            participants: [String]
-        ) {
-            self.id = id
-            self.title = title
-            self.theme = theme
-            self.date = date
-            self.place = place
-            self.participants = participants
-        }
-    }
-
-    public enum Action: Equatable {}
-
-    public var body: some ReducerProtocol<State, Action> {
-        EmptyReducer()
-    }
-}
 
 // MARK: - ConfirmedDetailView
 
 public struct PromiseDetailView: View {
     @Environment(\.screenSize) var screenSize
 
-    let store: StoreOf<PromiseDetailFeature>
+    let state: State
 
-    public init(store: StoreOf<PromiseDetailFeature>) {
-        self.store = store
+    public init(state: State) {
+        self.state = state
     }
 
     public var body: some View {
-        WithViewStore(self.store) { viewStore in
-            VStack {
-                PDS.Icon.illustDetail.image
-                    .resizable()
-                    .zIndex(1)
-                    .offset(y: 32)
-                    .frame(width: 64, height: 64)
+        VStack {
+            PDS.Icon.illustDetail.image
+                .resizable()
+                .zIndex(1)
+                .offset(y: 32)
+                .frame(width: 64, height: 64)
 
-                VStack(alignment: .leading) {
-                    Group {
-                        Text(viewStore.theme)
-                            .bold()
-                            .font(.title)
-                            .foregroundColor(PColor.purple9.scale)
+            VStack(alignment: .leading) {
+                Group {
+                    Text(state.theme)
+                        .bold()
+                        .font(.title)
+                        .foregroundColor(PColor.purple9.scale)
 
-                        Text(viewStore.title)
-                            .foregroundColor(PColor.cGray2.scale)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .center)
-
-                    Rectangle()
-                        .frame(height: 1)
-                        .foregroundColor(PColor.gray3.scale)
-
-                    VStack(alignment: .leading, spacing: 16) {
-                        makeContentView(
-                            title: "날짜/시간",
-                            content: viewStore.date
-                        )
-
-                        makeContentView(
-                            title: "장소",
-                            content: viewStore.place
-                        )
-
-                        makeContentView(
-                            title: "참여자",
-                            content: viewStore.participants
-                                .sorted(by: <)
-                                .joinedNames(separator: ", ")
-                        )
-                    }
-                    .padding(.top)
+                    Text(state.title)
+                        .foregroundColor(PColor.cGray2.scale)
                 }
-                .padding(EdgeInsets(top: 32, leading: 20, bottom: 32, trailing: 20))
-                .background(PColor.gray1.scale)
-                .frame(width: screenSize.width * 0.9, alignment: .leading)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(PColor.gray3.scale, lineWidth: 1)
-                )
+                .frame(maxWidth: .infinity, alignment: .center)
+
+                Rectangle()
+                    .frame(height: 1)
+                    .foregroundColor(PColor.gray3.scale)
+
+                VStack(alignment: .leading, spacing: 16) {
+                    makeContentView(
+                        title: "날짜/시간",
+                        content: formatter.string(from: state.date)
+                    )
+
+                    makeContentView(
+                        title: "장소",
+                        content: state.place
+                    )
+
+                    makeContentView(
+                        title: "참여자",
+                        content: state.participants
+                            .sorted(by: <)
+                            .joinedNames(separator: ", ")
+                    )
+                }
+                .padding(.top)
             }
-            .offset(y: -screenSize.height * 0.1)
+            .padding(EdgeInsets(top: 32, leading: 20, bottom: 32, trailing: 20))
+            .background(PColor.gray1.scale)
+            .frame(width: screenSize.width * 0.9, alignment: .leading)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(PColor.gray3.scale, lineWidth: 1)
+            )
         }
+        .offset(y: -screenSize.height * 0.1)
     }
 
     private func makeContentView(title: String, content: String) -> some View {
@@ -124,21 +86,52 @@ public struct PromiseDetailView: View {
     }
 }
 
+public extension PromiseDetailView {
+    struct State: Equatable, Identifiable {
+        public let id: UUID
+        let title: String
+        let theme: String
+        let date: Date
+        let place: String
+        let participants: [String]
+
+        public init(
+            id: UUID,
+            title: String,
+            theme: String,
+            date: Date,
+            place: String,
+            participants: [String]
+        ) {
+            self.id = id
+            self.title = title
+            self.theme = theme
+            self.date = date
+            self.place = place
+            self.participants = participants
+        }
+    }
+}
+
+private let formatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "M월 d일 a h시 m분"
+    formatter.locale = .init(identifier: "KO")
+
+    return formatter
+}()
+
 #if DEBUG
     struct ConfirmedDetailView_Previews: PreviewProvider {
         static var previews: some View {
-            PromiseDetailView(store:
+            PromiseDetailView(state:
                 .init(
-                    initialState:
-                    PromiseDetailFeature.State(
-                        id: UUID(),
-                        title: "약속명",
-                        theme: "여행",
-                        date: "2023",
-                        place: "강남",
-                        participants: ["정인혜", "이은영"]
-                    ),
-                    reducer: PromiseDetailFeature()._printChanges()
+                    id: UUID(),
+                    title: "약속명",
+                    theme: "여행",
+                    date: .now,
+                    place: "강남",
+                    participants: ["정인혜", "이은영"]
                 )
             )
         }


### PR DESCRIPTION
## 작업 내용
- 엑션이 존재하지 않는 뷰에 한에서 TCA를 적용하지 않는게 좋아보입니다.
위와 같이 생각한 이유는, 불필요한 추가작업이 항상 동반됩니다. 스토어를 스코핑하는 과정에서,
ParentAction을 생성하게 되는데 이 과정에서  ParentAction은 사용되지 않는 엑션을 만드는것은 물론, 핸들링까지 해야합니다.
추후 테스트 코드를 작성할 때, 혼동을 유발시키는 코드가 될 거 같아서 위와 같이 제안드립니다.

- 날짜 타입을 string으로 변경해서 뷰에서 보여주게 될 경우, 상태 값을 string 갖는게 아닌, 뷰에서 처리할 떄, DateFormatter, 혹은 Date().formatted을 사용해서 처리하시길 권장드립니다. 해당 이유론, 여러가지 화면에서 다른 Date의 형태값을 사용하고 있습니다. 이를 모두 충족 시키기 위해서 사용하는 부분에서 변경하는게 자율성이 훨씬 높을 것 같습니다.

<br>

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [ ] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [ ] 관련 이슈 연결
