### PR TITLE
[PI-21] 홈 컨테이너에서 바텀 시트 적용

### DIFF
--- a/AppPackage/Package.swift
+++ b/AppPackage/Package.swift
@@ -127,6 +127,7 @@ let package = Package(
                 "MakePromise",
                 "HomeFeature",
                 "CalendarFeature",
+                "SwiftUIHelper",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "SwiftUINavigation", package: "swiftui-navigation")
             ]

--- a/AppPackage/Sources/CalendarFeature/Calendar/CalendarCore.swift
+++ b/AppPackage/Sources/CalendarFeature/Calendar/CalendarCore.swift
@@ -20,6 +20,10 @@ public struct CalendarCore: ReducerProtocol {
             self.selectedMonth = selectedMonth
             self.selectedDates = selectedDates
         }
+
+        public subscript(_ date: Date) -> Day? {
+            monthList[id: selectedMonth]?[date]
+        }
     }
 
     public enum Action: BindableAction, Equatable {
@@ -274,20 +278,20 @@ private extension CalendarType {
             let todayIndex = unwrappedItem[currentMonthIndex].dayStateList
                 .firstIndex(where: { $0.id == .today }) ?? .zero
             unwrappedItem[currentMonthIndex].dayStateList[0].day.promiseList = [
-                .init(type: .meeting, date: .today, name: "모각코 🙌"),
-                .init(type: .etc, date: .today, name: "YAPP 런칭 약속 👌👌👌👌"),
-                .init(type: .meal, date: .today, name: "돼지파티 약속 🐷")
+                .init(type: .meeting, date: .today, name: "모각코 🙌", place: "", participants: []),
+                .init(type: .etc, date: .today, name: "YAPP 런칭 약속 👌👌👌👌", place: "", participants: []),
+                .init(type: .meal, date: .today, name: "돼지파티 약속 🐷", place: "", participants: [])
             ]
 
             unwrappedItem[currentMonthIndex].dayStateList[todayIndex].day.promiseList = [
-                .init(type: .meeting, date: .today, name: "모각코 🙌"),
-                .init(type: .etc, date: .today, name: "YAPP 런칭 약속 👌👌👌👌"),
-                .init(type: .meal, date: .today, name: "돼지파티 약속 🐷"),
-                .init(type: .meeting, date: .today, name: "애플 로그인 약속 🍎"),
-                .init(type: .etc, date: .today, name: "🫥 🤠 🫥"),
-                .init(type: .etc, date: .today, name: "🫥 🤠 🫥"),
-                .init(type: .etc, date: .today, name: "🫥 🤠 🫥"),
-                .init(type: .etc, date: .today, name: "🫥 🤠 🫥")
+                .init(type: .meeting, date: .today, name: "모각코 🙌", place: "", participants: []),
+                .init(type: .etc, date: .today, name: "YAPP 런칭 약속 👌👌👌👌", place: "", participants: []),
+                .init(type: .meal, date: .today, name: "돼지파티 약속 🐷", place: "", participants: []),
+                .init(type: .meeting, date: .today, name: "애플 로그인 약속 🍎", place: "", participants: []),
+                .init(type: .etc, date: .today, name: "🫥 🤠 🫥", place: "", participants: []),
+                .init(type: .etc, date: .today, name: "🫥 🤠 🫥", place: "", participants: []),
+                .init(type: .etc, date: .today, name: "🫥 🤠 🫥", place: "", participants: []),
+                .init(type: .etc, date: .today, name: "🫥 🤠 🫥", place: "", participants: [])
             ]
             result
                 .append(

--- a/AppPackage/Sources/CalendarFeature/Calendar/CalendarCore.swift
+++ b/AppPackage/Sources/CalendarFeature/Calendar/CalendarCore.swift
@@ -37,7 +37,7 @@ public struct CalendarCore: ReducerProtocol {
         case createMonthStateList(type: CalendarType, range: CalendarClient.DateRange)
         case updateMonthStateList(CalendarClient.DateRange, TaskResult<[MonthState]>)
         case month(id: MonthCore.State.ID, action: MonthCore.Action)
-        case promiseTapped(Promise.ID)
+        case promiseTapped(Date, Promise.ID)
         case overSelection
         case binding(BindingAction<State>)
     }

--- a/AppPackage/Sources/CalendarFeature/Calendar/CalendarView.swift
+++ b/AppPackage/Sources/CalendarFeature/Calendar/CalendarView.swift
@@ -268,7 +268,7 @@ public struct CalendarView: View {
                                             .font(.system(size: 13))
                                             .foregroundColor(PDS.COLOR.gray5.scale)
                                     }
-                                    .onTapGesture { viewStore.send(.promiseTapped(promise.id)) }
+                                    .onTapGesture { viewStore.send(.promiseTapped(promise.date, promise.id)) }
                                 }
                             }
                         }
@@ -319,8 +319,8 @@ extension CalendarView {
             case let .scrollViewOffsetChanged(type: type, index: index):
                 return .scrollViewOffsetChanged(type: type, index: index)
 
-            case let .promiseTapped(id):
-                return .promiseTapped(id)
+            case let .promiseTapped(date, id):
+                return .promiseTapped(date, id)
 
             case let .binding(item):
                 return .binding(item.pullback(\.viewState))
@@ -333,7 +333,7 @@ extension CalendarView {
         case rightSideButtonTapped
         case formChangeButtonTapped
         case scrollViewOffsetChanged(type: CalendarType, index: Int)
-        case promiseTapped(Promise.ID)
+        case promiseTapped(Date, Promise.ID)
         case binding(BindingAction<ViewState>)
     }
 }

--- a/AppPackage/Sources/CalendarFeature/Day/DayView.swift
+++ b/AppPackage/Sources/CalendarFeature/Day/DayView.swift
@@ -150,17 +150,23 @@ private extension Color {
                                 .init(
                                     type: .meal,
                                     date: .today,
-                                    name: "앱 출시하기"
+                                    name: "앱 출시하기",
+                                    place: "",
+                                    participants: []
                                 ),
                                 .init(
                                     type: .meal,
                                     date: .today,
-                                    name: "앱 출시하기"
+                                    name: "앱 출시하기",
+                                    place: "",
+                                    participants: []
                                 ),
                                 .init(
                                     type: .meal,
                                     date: .today,
-                                    name: "앱 출시하기"
+                                    name: "앱 출시하기",
+                                    place: "",
+                                    participants: []
                                 )
                             ],
                             isFaded: false,

--- a/AppPackage/Sources/CommonView/PromiseDetailView.swift
+++ b/AppPackage/Sources/CommonView/PromiseDetailView.swift
@@ -8,6 +8,7 @@
 import DesignSystem
 import SwiftUI
 import SwiftUIHelper
+import Entity
 
 // MARK: - ConfirmedDetailView
 
@@ -109,6 +110,15 @@ public extension PromiseDetailView {
             self.date = date
             self.place = place
             self.participants = participants
+        }
+        
+        public init(promise: Promise) {
+            self.id = promise.id
+            self.title = promise.name
+            self.theme = promise.type.description
+            self.date = promise.date
+            self.place = promise.place
+            self.participants = promise.participants
         }
     }
 }

--- a/AppPackage/Sources/CommonView/PromiseItem.swift
+++ b/AppPackage/Sources/CommonView/PromiseItem.swift
@@ -17,8 +17,11 @@ public struct PromiseItem: View {
 
             VStack(alignment: .leading, spacing: .zero) {
                 Text(formatter.string(from: state.date))
+                    .foregroundColor(PDS.COLOR.gray5.scale)
+                    .font(.planz(.body12))
 
                 Text(state.name)
+                    .font(.planz(.subtitle14))
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .background { Color.white }
@@ -40,6 +43,12 @@ public extension PromiseItem {
             self.promiseType = promiseType
             self.name = name
             self.date = date
+        }
+        
+        public init(promise: Promise) {
+            self.promiseType = promise.type
+            self.name = promise.name
+            self.date = promise.date
         }
     }
 }

--- a/AppPackage/Sources/CommonView/PromiseItem.swift
+++ b/AppPackage/Sources/CommonView/PromiseItem.swift
@@ -44,11 +44,11 @@ public extension PromiseItem {
             self.name = name
             self.date = date
         }
-        
+
         public init(promise: Promise) {
-            self.promiseType = promise.type
-            self.name = promise.name
-            self.date = promise.date
+            promiseType = promise.type
+            name = promise.name
+            date = promise.date
         }
     }
 }

--- a/AppPackage/Sources/Entity/Promise.swift
+++ b/AppPackage/Sources/Entity/Promise.swift
@@ -1,6 +1,18 @@
 import Foundation
 
-public enum PromiseType: Equatable {
+public enum PromiseType: Equatable, CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .meal:
+            return "식사"
+        case .meeting:
+            return "미팅"
+        case .trip:
+            return "여행"
+        case .etc:
+            return "기타"
+        }
+    }
     case meal
     case meeting
     case trip
@@ -12,16 +24,22 @@ public struct Promise: Identifiable, Equatable {
     public let type: PromiseType
     public let date: Date
     public let name: String
+    public let place: String
+    public let participants: [String]
 
     public init(
         id: UUID = .init(),
         type: PromiseType,
         date: Date,
-        name: String
+        name: String,
+        place: String,
+        participants: [String]
     ) {
         self.id = id
         self.type = type
         self.date = date
         self.name = name
+        self.place = place
+        self.participants = participants
     }
 }

--- a/AppPackage/Sources/HomeContainerFeature/PromiseListView.swift
+++ b/AppPackage/Sources/HomeContainerFeature/PromiseListView.swift
@@ -99,16 +99,16 @@ private extension Date {
 #if DEBUG
 struct PromiseListView_Previews: PreviewProvider {
     static var previews: some View {
-        ZStack { }
+        ZStack {}
             .sheet(isPresented: .constant(true)) {
                 PromiseListView(
                     store: .init(
                         initialState: .init(
                             date: .now,
                             promiseList: [
-                                .init(type: .etc, date: .now, name: "돼지파티 약속"),
-                                .init(type: .etc, date: .now, name: "ABC1"),
-                                .init(type: .etc, date: .now, name: "ABC2")
+                                .init(type: .etc, date: .now, name: "돼지파티 약속", place: "", participants: []),
+                                .init(type: .etc, date: .now, name: "ABC1", place: "", participants: []),
+                                .init(type: .etc, date: .now, name: "ABC2", place: "", participants: [])
                             ]
                         ),
                         reducer: PromiseListCore()

--- a/AppPackage/Sources/HomeContainerFeature/PromiseListView.swift
+++ b/AppPackage/Sources/HomeContainerFeature/PromiseListView.swift
@@ -1,0 +1,121 @@
+import ComposableArchitecture
+import Foundation
+import SwiftUI
+import DesignSystem
+import Entity
+import CommonView
+
+public struct PromiseListCore: ReducerProtocol {
+    public struct State: Equatable {
+        let date: Date
+        var promiseList: [Promise]
+    }
+    
+    public enum Action: Equatable {
+        public enum Delegate: Equatable {
+            case dismiss
+        }
+        
+        case closeButtonTapped
+        case delegate(Delegate)
+    }
+    
+    public var body: some ReducerProtocolOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .closeButtonTapped:
+                return .send(.delegate(.dismiss))
+                
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+
+struct PromiseListView: View {
+    let store: StoreOf<PromiseListCore>
+    @ObservedObject var viewStore: ViewStoreOf<PromiseListCore>
+    
+    init (store: StoreOf<PromiseListCore>) {
+        self.store = store
+        self.viewStore = ViewStore(store)
+    }
+    
+    var body: some View {
+            VStack {
+                HStack {
+                    Text(viewStore.date.headerString + Resource.Text.headerText)
+                        .foregroundColor(PDS.COLOR.gray8.scale)
+                        .font(.planz(.body12))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    
+                    Button(action: { }) {
+                        PDS.Icon.close.image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 24, height: 24)
+                    }
+                    .padding(.vertical, 24)
+                }
+                
+                ScrollView(showsIndicators: false) {
+                    
+                    ForEach(viewStore.promiseList) {
+                        PromiseItem(state: .init(promise: $0))
+                        }
+                }
+                .opacity(viewStore.promiseList.isEmpty ? .zero : 1)
+                
+                Text(Resource.Text.emptyPromiseList)
+                    .foregroundColor(PDS.COLOR.gray5.scale)
+                    .font(.planz(.body16))
+                    .opacity(viewStore.promiseList.isEmpty ? 1: .zero)
+            }
+            .padding(.horizontal, 20)
+    }
+}
+
+private extension PromiseListView {
+    struct Resource {
+        struct Text {
+            static let headerText = " 약속"
+            static let emptyPromiseList = "오늘의 약속이 없습니다."
+        }
+    }
+}
+
+private extension Date {
+    var headerString: String {
+        formatted(
+            .dateTime
+                .month()
+                .day()
+        )
+    }
+}
+
+#if DEBUG
+struct PromiseListView_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack { }
+            .sheet(isPresented: .constant(true)) {
+                PromiseListView(
+                    store: .init(
+                        initialState: .init(
+                            date: .now,
+                            promiseList: [
+                                .init(type: .etc, date: .now, name: "돼지파티 약속"),
+                                .init(type: .etc, date: .now, name: "ABC1"),
+                                .init(type: .etc, date: .now, name: "ABC2")
+                            ]
+                        ),
+                        reducer: PromiseListCore()
+                    )
+                )
+            }
+    }
+}
+#endif
+

--- a/AppPackage/Sources/SwiftUIHelper/View.swift
+++ b/AppPackage/Sources/SwiftUIHelper/View.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+import Foundation
+
+public extension View {
+    @ViewBuilder
+    public func hidden(_ hidden: Bool, _ isSpace: Bool = false) -> some View {
+        modifier(HiddenViewModifier(hidden: hidden, isSpace: isSpace))
+    }
+}
+
+public struct HiddenViewModifier: ViewModifier {
+    var hidden: Bool
+    var isSpace: Bool
+    
+    public init(hidden: Bool, isSpace: Bool) {
+        self.hidden = hidden
+        self.isSpace = isSpace
+    }
+    
+    public func body(content: Content) -> some View {
+        if hidden {
+            if isSpace {
+                content.hidden()
+            }
+        } else {
+            content
+        }
+    }
+}


### PR DESCRIPTION
## ISSUE
- resolved [#[PI-21]](https://planz-growth.atlassian.net/browse/PI-21)

<br>

## 작업 내용
- 홈 컨테이너 화면에서 a를 선택했을 때, 바텀 시트가 노출되도록 구현했습니다.

a) 바텀 시트가 노출될 수 있는 시작점
1. 달력에서 DayView를 눌렀을 때 -> PromiseListView가 노출되도록 구현했습니다.
2. 오늘의 약속에서 PromiseItem을 눌렀을 때 -> PromiseDetail로 이동하도록 구현했습니다.
3. Calendar Form이 list일 때, row를 탭했을 때 -> PromiseDetail로 이동하도록 구현했습니다.

선택된 Promise가 존재하지 않을 경우, 바텀 시트를 확장시킬 수 없으며, 바텀 시트의 크기가 작아질 경우 선택된 Promise를 nil로 변경합니다.

<br>

## 실행 화면

| Screen Shot | Screen Shot |
| ----------- | ----------- |
| <img width="435" alt="Screenshot 2023-04-05 at 20 59 31" src="https://user-images.githubusercontent.com/48466830/230074083-1164cb24-d57e-4d28-8b87-de23464598c6.png">|<img width="422" alt="Screenshot 2023-04-05 at 20 59 39" src="https://user-images.githubusercontent.com/48466830/230074094-471bf161-3510-4faa-b415-aac6f224fdf9.png">|



<br>

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [ ] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
