### PR TITLE
[PI-19] 약속관리 화면에서의 mock API 연결(진행중)

### DIFF
--- a/AppPackage/Package.swift
+++ b/AppPackage/Package.swift
@@ -111,7 +111,8 @@ let package = Package(
                 "DesignSystem",
                 "CommonView",
                 .product(name: "SwiftUINavigation", package: "swiftui-navigation"),
-                .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
+                .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+                .product(name: "APIClient", package: "Planz-iOS-APIClient")
             ]
         ),
         .target(

--- a/AppPackage/Sources/PromiseManagement/Common/RoleType.swift
+++ b/AppPackage/Sources/PromiseManagement/Common/RoleType.swift
@@ -9,7 +9,7 @@
 import DesignSystem
 import SwiftUI
 
-enum RoleType: String {
+public enum RoleType: String {
     case leader
     case general
 

--- a/AppPackage/Sources/PromiseManagement/Confirmed/ConfirmedCellView.swift
+++ b/AppPackage/Sources/PromiseManagement/Confirmed/ConfirmedCellView.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 public struct ConfirmedCell: ReducerProtocol {
     public struct State: Equatable, Identifiable {
-        public let id: UUID
+        public let id: Int
         let title: String
         let role: RoleType
         let leaderName: String
@@ -78,7 +78,7 @@ struct ConfirmedCellView_Previews: PreviewProvider {
         ConfirmedCellView(store: Store(
             initialState:
             ConfirmedCell.State(
-                id: UUID(),
+                id: 0,
                 title: "가나다라마바사아자차카파타하이",
                 role: .leader,
                 leaderName: "LeaderName",

--- a/AppPackage/Sources/PromiseManagement/Confirmed/ConfirmedListView.swift
+++ b/AppPackage/Sources/PromiseManagement/Confirmed/ConfirmedListView.swift
@@ -91,7 +91,7 @@ struct ConfirmedListView: View {
 extension IdentifiedArray where ID == ConfirmedCell.State.ID, Element == ConfirmedCell.State {
     static let mock: Self = [
         ConfirmedCell.State(
-            id: UUID(),
+            id: 0,
             title: "확정 약속1",
             role: .general,
             leaderName: "김세현",
@@ -102,7 +102,7 @@ extension IdentifiedArray where ID == ConfirmedCell.State.ID, Element == Confirm
             participants: ["윤여정", "권지윤", "이한나", "김이정"]
         ),
         ConfirmedCell.State(
-            id: UUID(),
+            id: 1,
             title: "확정 약속2",
             role: .leader,
             leaderName: "강빛나",
@@ -113,7 +113,7 @@ extension IdentifiedArray where ID == ConfirmedCell.State.ID, Element == Confirm
             participants: ["이훈", "최백준"]
         ),
         ConfirmedCell.State(
-            id: UUID(),
+            id: 2,
             title: "확정 약속3",
             role: .general,
             leaderName: "한지희",

--- a/AppPackage/Sources/PromiseManagement/ManagementView.swift
+++ b/AppPackage/Sources/PromiseManagement/ManagementView.swift
@@ -113,27 +113,26 @@ public struct PromiseManagement: ReducerProtocol {
 
     private func initializeAPIRequest(send: Send<Action>) async {
         do {
-            // ERROR: - 확정약속 mock 데이터가 정의되지 않아서 에러 발생
-//            try await APIClient.mock.request(route: .promise(.fetchAll(.user)))
-
             async let confirmedFetchResponse: Void = send(.confirmedFetchAllResponse(
-                await APIClient.mock.request(route: .promising(.fetchAll), as: SharedModels.PromisingTimeStamps.self)
-                    .promisingTimeStamps
-                    .map {
-                        ConfirmedCell.State(
-                            id: $0.id,
-                            title: $0.promisingName,
-                            role: $0.isOwner
-                                ? RoleType.leader
-                                : RoleType.general,
-                            leaderName: $0.owner.name,
-                            replyPeopleCount: $0.members.count,
-                            theme: $0.category.type,
-                            date: $0.startDate.toString(),
-                            place: $0.placeName,
-                            participants: $0.members.map(\.name)
-                        )
-                    }
+                await APIClient.mock.request(
+                    route: .promise(.fetchAll(.user)),
+                    as: [SharedModels.Promise].self
+                )
+                .map {
+                    ConfirmedCell.State(
+                        id: $0.id,
+                        title: $0.name,
+                        role: $0.isOwner
+                            ? RoleType.leader
+                            : RoleType.general,
+                        leaderName: $0.owner.name,
+                        replyPeopleCount: $0.members.count,
+                        theme: $0.category.type,
+                        date: $0.date.toString(),
+                        place: $0.place,
+                        participants: $0.members.map(\.name)
+                    )
+                }
             ))
 
             async let standbyFetchResponse: Void = try send(.standbyFetchAllResponse(
@@ -159,7 +158,7 @@ public struct PromiseManagement: ReducerProtocol {
                     }
             ))
 
-            let _ = try await (standbyFetchResponse, confirmedFetchResponse)
+            let responses = try await (standbyFetchResponse, confirmedFetchResponse)
         } catch {}
     }
 }

--- a/AppPackage/Sources/PromiseManagement/ManagementView.swift
+++ b/AppPackage/Sources/PromiseManagement/ManagementView.swift
@@ -69,7 +69,7 @@ public struct PromiseManagement: ReducerProtocol {
                 switch action {
                 case let .showDetailView(item):
                     state.detailItem = PromiseDetailView.State(
-                        id: item.id,
+                        id: UUID(uuidString: String(item.id)) ?? UUID(),
                         title: item.title,
                         theme: item.theme,
 
@@ -89,7 +89,7 @@ public struct PromiseManagement: ReducerProtocol {
                 switch action {
                 case let .showDetailView(item):
                     state.detailItem = PromiseDetailView.State(
-                        id: item.id,
+                        id: UUID(uuidString: String(item.id)) ?? UUID(),
                         title: item.title,
                         theme: "테마",
                         date: .now,
@@ -121,7 +121,7 @@ public struct PromiseManagement: ReducerProtocol {
                     .promisingTimeStamps
                     .map {
                         ConfirmedCell.State(
-                            id: UUID(uuidString: String($0.id)) ?? UUID(),
+                            id: $0.id,
                             title: $0.promisingName,
                             role: $0.isOwner
                                 ? RoleType.leader
@@ -140,7 +140,7 @@ public struct PromiseManagement: ReducerProtocol {
                 await APIClient.mock.request(route: .promising(.fetchAll), as: SharedModels.PromisingTimeStamps.self)
                     .promisingTimeStamps
                     .map { StandbyCell.State(
-                        id: UUID(uuidString: String($0.id)) ?? UUID(),
+                        id: $0.id,
                         title: $0.promisingName,
                         role:
                         $0.isOwner

--- a/AppPackage/Sources/PromiseManagement/Standby/StandbyCellView.swift
+++ b/AppPackage/Sources/PromiseManagement/Standby/StandbyCellView.swift
@@ -14,7 +14,43 @@ public struct StandbyCell: ReducerProtocol {
         public let id: UUID
         let title: String
         let role: RoleType
-        let names: [String]
+        let members: [String]
+        let startDate: Date
+        let endDate: Date
+        let category: Category
+        let placeName: String
+
+        public struct Category: Equatable {
+            let id: Int
+            let keyword: String
+            let type: String
+
+            public init(id: Int, keyword: String, type: String) {
+                self.id = id
+                self.keyword = keyword
+                self.type = type
+            }
+        }
+
+        public init(
+            id: UUID,
+            title: String,
+            role: RoleType,
+            members: [String],
+            startDate: Date,
+            endDate: Date,
+            category: Category,
+            placeName: String
+        ) {
+            self.id = id
+            self.title = title
+            self.role = role
+            self.members = members
+            self.startDate = startDate
+            self.endDate = endDate
+            self.category = category
+            self.placeName = placeName
+        }
     }
 
     public enum Action: Equatable {
@@ -47,7 +83,7 @@ struct StandbyCellView: View {
         init(state: StandbyCell.State) {
             title = state.title
             role = state.role
-            namesText = state.names
+            namesText = state.members
                 .sorted(by: <)
                 .joined(separator: ", ")
         }
@@ -88,7 +124,11 @@ struct StandbyCellView_Previews: PreviewProvider {
                 id: UUID(),
                 title: "가나다라마바사아자차카파타하이",
                 role: .leader,
-                names: ["김세현", "한지희", "여윤정", "조하은", "이은희", "조운", "나세리", "도진우", "민지혜"]
+                members: ["김세현", "한지희", "여윤정", "조하은", "이은희", "조운", "나세리", "도진우", "민지혜"],
+                startDate: .now,
+                endDate: .now + 3600,
+                category: .init(id: 0, keyword: "keyword", type: "type"),
+                placeName: "강남"
             ),
             reducer: StandbyCell()._printChanges()
         ))

--- a/AppPackage/Sources/PromiseManagement/Standby/StandbyCellView.swift
+++ b/AppPackage/Sources/PromiseManagement/Standby/StandbyCellView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 public struct StandbyCell: ReducerProtocol {
     public struct State: Equatable, Identifiable {
-        public let id: UUID
+        public let id: Int
         let title: String
         let role: RoleType
         let members: [String]
@@ -33,7 +33,7 @@ public struct StandbyCell: ReducerProtocol {
         }
 
         public init(
-            id: UUID,
+            id: Int,
             title: String,
             role: RoleType,
             members: [String],
@@ -121,7 +121,7 @@ struct StandbyCellView_Previews: PreviewProvider {
         StandbyCellView(store: Store(
             initialState:
             StandbyCell.State(
-                id: UUID(),
+                id: 0,
                 title: "가나다라마바사아자차카파타하이",
                 role: .leader,
                 members: ["김세현", "한지희", "여윤정", "조하은", "이은희", "조운", "나세리", "도진우", "민지혜"],

--- a/AppPackage/Sources/PromiseManagement/Standby/StandbyListView.swift
+++ b/AppPackage/Sources/PromiseManagement/Standby/StandbyListView.swift
@@ -82,9 +82,9 @@ struct StandbyListView: View {
 
 extension IdentifiedArray where ID == StandbyCell.State.ID, Element == StandbyCell.State {
     static let mock: Self = [
-        StandbyCell.State(id: UUID(), title: "약속1", role: .general, members: ["여윤정", "한지희", "김세현", "조하은", "일리윤", "이은정", "강빛나"], startDate: .now, endDate: .now + 3600, category: .init(id: 0, keyword: "keyword", type: "type"), placeName: "강남"),
-        StandbyCell.State(id: UUID(), title: "약속2", role: .general, members: ["여윤정", "한지희", "김세현", "조하은"], startDate: .now, endDate: .now + 3600, category: .init(id: 0, keyword: "keyword", type: "type"), placeName: "홍대입구역"),
-        StandbyCell.State(id: UUID(), title: "약속3", role: .general, members: ["한지희", "김세현", "이은정", "강빛나"], startDate: .now, endDate: .now + 3600, category: .init(id: 0, keyword: "keyword", type: "type"), placeName: "여의도")
+        StandbyCell.State(id: 0, title: "약속1", role: .general, members: ["여윤정", "한지희", "김세현", "조하은", "일리윤", "이은정", "강빛나"], startDate: .now, endDate: .now + 3600, category: .init(id: 0, keyword: "keyword", type: "type"), placeName: "강남"),
+        StandbyCell.State(id: 1, title: "약속2", role: .general, members: ["여윤정", "한지희", "김세현", "조하은"], startDate: .now, endDate: .now + 3600, category: .init(id: 0, keyword: "keyword", type: "type"), placeName: "홍대입구역"),
+        StandbyCell.State(id: 2, title: "약속3", role: .general, members: ["한지희", "김세현", "이은정", "강빛나"], startDate: .now, endDate: .now + 3600, category: .init(id: 0, keyword: "keyword", type: "type"), placeName: "여의도")
     ]
 }
 

--- a/AppPackage/Sources/PromiseManagement/Standby/StandbyListView.swift
+++ b/AppPackage/Sources/PromiseManagement/Standby/StandbyListView.swift
@@ -82,9 +82,36 @@ struct StandbyListView: View {
 
 extension IdentifiedArray where ID == StandbyCell.State.ID, Element == StandbyCell.State {
     static let mock: Self = [
-        StandbyCell.State(id: 0, title: "약속1", role: .general, members: ["여윤정", "한지희", "김세현", "조하은", "일리윤", "이은정", "강빛나"], startDate: .now, endDate: .now + 3600, category: .init(id: 0, keyword: "keyword", type: "type"), placeName: "강남"),
-        StandbyCell.State(id: 1, title: "약속2", role: .general, members: ["여윤정", "한지희", "김세현", "조하은"], startDate: .now, endDate: .now + 3600, category: .init(id: 0, keyword: "keyword", type: "type"), placeName: "홍대입구역"),
-        StandbyCell.State(id: 2, title: "약속3", role: .general, members: ["한지희", "김세현", "이은정", "강빛나"], startDate: .now, endDate: .now + 3600, category: .init(id: 0, keyword: "keyword", type: "type"), placeName: "여의도")
+        StandbyCell.State(
+            id: 0,
+            title: "약속1",
+            role: .general,
+            members: ["여윤정", "한지희", "김세현", "조하은", "일리윤", "이은정", "강빛나"],
+            startDate: .now,
+            endDate: .now + 3600,
+            category: .init(id: 0, keyword: "keyword", type: "type"),
+            placeName: "강남"
+        ),
+        StandbyCell.State(
+            id: 1,
+            title: "약속2",
+            role: .general,
+            members: ["여윤정", "한지희", "김세현", "조하은"],
+            startDate: .now,
+            endDate: .now + 3600,
+            category: .init(id: 0, keyword: "keyword", type: "type"),
+            placeName: "홍대입구역"
+        ),
+        StandbyCell.State(
+            id: 2,
+            title: "약속3",
+            role: .general,
+            members: ["한지희", "김세현", "이은정", "강빛나"],
+            startDate: .now,
+            endDate: .now + 3600,
+            category: .init(id: 0, keyword: "keyword", type: "type"),
+            placeName: "여의도"
+        )
     ]
 }
 

--- a/AppPackage/Sources/PromiseManagement/Standby/StandbyListView.swift
+++ b/AppPackage/Sources/PromiseManagement/Standby/StandbyListView.swift
@@ -82,15 +82,9 @@ struct StandbyListView: View {
 
 extension IdentifiedArray where ID == StandbyCell.State.ID, Element == StandbyCell.State {
     static let mock: Self = [
-        StandbyCell.State(
-            id: UUID(), title: "약속1", role: .general, names: ["여윤정", "한지희", "김세현", "조하은", "일리윤", "이은정", "강빛나"]
-        ),
-        StandbyCell.State(
-            id: UUID(), title: "약속2", role: .leader, names: ["여윤정", "한지희", "김세현", "조하은"]
-        ),
-        StandbyCell.State(
-            id: UUID(), title: "약속3", role: .general, names: ["한지희", "김세현", "이은정", "강빛나"]
-        )
+        StandbyCell.State(id: UUID(), title: "약속1", role: .general, members: ["여윤정", "한지희", "김세현", "조하은", "일리윤", "이은정", "강빛나"], startDate: .now, endDate: .now + 3600, category: .init(id: 0, keyword: "keyword", type: "type"), placeName: "강남"),
+        StandbyCell.State(id: UUID(), title: "약속2", role: .general, members: ["여윤정", "한지희", "김세현", "조하은"], startDate: .now, endDate: .now + 3600, category: .init(id: 0, keyword: "keyword", type: "type"), placeName: "홍대입구역"),
+        StandbyCell.State(id: UUID(), title: "약속3", role: .general, members: ["한지희", "김세현", "이은정", "강빛나"], startDate: .now, endDate: .now + 3600, category: .init(id: 0, keyword: "keyword", type: "type"), placeName: "여의도")
     ]
 }
 


### PR DESCRIPTION
간단한 작업인데 반해 시간 소요가 많이 된것 같아 중간 과정을 공유합니다 🙇🏻‍♀️

## ISSUE
- resolved [#[PI-19]](https://planz-growth.atlassian.net/browse/PI-19)

<br>

## 작업 내용
- mock 데이터를 가져와 화면에 보여줍니다
- 보여줄 가짜 데이터는 API 모듈에서 정의된 것을 사용

## 작업 안된 내용
- 확정 약속 리스트는 현재 mock 데이터를 반환하지 않아서 대기중 약속 API 를 2번 호출하여 화면에 보여주도록 했습니다
- [APIClient PR](https://github.com/Team-Planz/Planz-iOS-APIClient/pull/3) 이 merge 되면 수정할 예정입니다
- 약속 상세화면에서 API 호출 => 마찬가지로 merge 되고 난 후에 작업

## 어려웠던 점
동시에 2개의 API 를 동시에 호출하여 각각 다른 화면에 반영하는 것.
Combine, async await 2가지 방법중에 async await 을 사용하여 해결

<br>

## Check List
- [ ] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [ ] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [ ] 관련 이슈 연결
